### PR TITLE
fix(core): strip trailing slash from _sourceFile in navDesignatedIndexFiles

### DIFF
--- a/packages/core/src/engine/generator.ts
+++ b/packages/core/src/engine/generator.ts
@@ -178,8 +178,9 @@ export async function renderPages({ config, srcDir, fallbackSrcDir, outputDir, h
       if (item.children) {
         extractNavIndexes(item.children);
       } else if (item._sourceFile) {
-        // _sourceFile is the original path like '/highlighting' - normalize to relative path
-        navDesignatedIndexFiles.add(item._sourceFile.replace(/^\//, ''));
+        // _sourceFile is the original path like '/highlighting/' - normalize to relative path
+        // and strip trailing slash to match relWithoutExt format used during comparison
+        navDesignatedIndexFiles.add(item._sourceFile.replace(/^\//, '').replace(/\/$/, ''));
       }
     }
   };


### PR DESCRIPTION
## Bug

When a folder contains `.md` files but **no `index.md`**, the auto-router promotes the first file to the folder-level URL (e.g. `_sourceFile` is stored, `path` is reassigned to `basePath`). However, clicking that nav link results in a **404**.

### Root Cause

In `auto-router.ts`, `normalizeInternalHref()` adds a trailing slash to `linkPath` before it is stored as `_sourceFile`:

```
_sourceFile = "/SA/feature-discovery/feature-active-reward-edit/"  ← trailing slash
```

In `generator.ts`, the Set is populated by stripping the leading slash only:

```ts
navDesignatedIndexFiles.add(item._sourceFile.replace(/^\//, ));
// → "SA/feature-discovery/feature-active-reward-edit/"  ← still has trailing slash
```

But `relWithoutExt` (the key used in `.has()`) has **no** trailing slash:

```ts
const relWithoutExt = relativePath.replace(/\.(md|markdown|ejs)$/i, );
// → "SA/feature-discovery/feature-active-reward-edit"  ← no trailing slash
```

So `navDesignatedIndexFiles.has(relWithoutExt)` is **always `false`**, meaning `isNavDesignatedIndex` is never set, `effectivelyIndex` stays `false`, and the file is output at `SA/feature-discovery/feature-active-reward-edit/index.html` instead of the intended `SA/feature-discovery/index.html`.

Result: nav link `/SA/feature-discovery` has no matching `index.html` → **404**.

### Reproduction

```
docs/
  SA/
    feature-discovery/
      my-page.md        ← no index.md in this folder
```

Expected: clicking `feature-discovery` in the sidebar → `200` (content of `my-page.md`)
Actual: **404** (`site/SA/feature-discovery/index.html` is never generated)

## Fix

Strip the trailing slash when normalising `_sourceFile` before adding to the Set, making it consistent with `relWithoutExt`:

```ts
// before
navDesignatedIndexFiles.add(item._sourceFile.replace(/^\//, ));

// after
navDesignatedIndexFiles.add(item._sourceFile.replace(/^\//, ).replace(/\/$/, ));
```

## Tested

- Built the fixed binary locally
- Removed `index.md` workaround from a project folder
- `site/SA/feature-discovery/index.html` now generated correctly
- Nav link `/SA/feature-discovery` → **HTTP 200** ✓