### PR TITLE
fix(core): remove file-promotion + slugify paths + clean dev output + full watch rebuild

### DIFF
--- a/packages/core/src/utils/auto-router.ts
+++ b/packages/core/src/utils/auto-router.ts
@@ -111,19 +111,6 @@ export function buildAutoNav(dir: string, basePath = '/'): any[] { // Default ba
     }
   }
 
-  // If no index exists at this level, and we have files, designate the first one as index
-  if (!indexExists && nav.length > 0) {
-    // Find first file (not a folder) - alphabetical after sorting (sorted below)
-    // But since sort hasn't happened yet, sort copies to pick the true first
-    const fileItems = nav.filter(n => !n.children).sort((a, b) => a.title.localeCompare(b.title));
-    if (fileItems.length > 0) {
-      const firstFile = fileItems[0];
-      // Store the original path before reassigning so the generator knows which file this is
-      firstFile._sourceFile = firstFile.path;
-      firstFile.path = basePath === '/' ? '/' : basePath;
-    }
-  }
-
   // Sort: Put index.md (Home) at the top, then sort alphabetically
   return nav.sort((a, b) => {
     // Check if path effectively points to current folder root


### PR DESCRIPTION
## Background

This PR follows #131. Four related bugs were found while investigating that issue.

---

## Fix 1 — Remove implicit file-promotion (`auto-router.ts`)

When a folder had `.md` files but no `index.md`, the first file was promoted to the folder URL, silently dropping its filename. This caused inconsistent URLs (files in folders with `index.md` kept their filename; files without did not) and made same-named files in sibling folders indistinguishable. **Removed the promotion block.** Every file now always generates a URL that includes its own filename.

---

## Fix 2 — Slugify path segments (`auto-router.ts` + `generator.ts`)

### Problem

Files and folders whose names contain **spaces or URL-unsafe characters** produced 404 in both dev and production:

```
docs/SA/my feature/page one.md
  nav link → ./SA/my feature/page one/   (literal space)
  browser  → /SA/my%20feature/page%20one/ (%20-encodes the space)
  server   → tries SA/my%20feature/ on disk  → not found → 404
```

`normalizeInternalHref` adds a trailing slash but does not slugify segments. The raw OS filename was used verbatim in both the nav href and the `site/` output path.

### Fix

Added a `slugifySegment` helper and applied it in both places:

- **`auto-router.ts`** — when building each `relPath` segment from `fs.readdirSync`
- **`generator.ts`** — when building `htmlOutputPath` from `relativePath`

Both sides use identical logic so the nav URL and the output file path always agree:

```
docs/SA/my feature/page one.md
  nav: /SA/my-feature/page-one/   ✓  200
  out: site/SA/my-feature/page-one/index.html  ✓
```

Slugification rules: spaces → `-`, `[^a-zA-Z0-9\-_.~]` → `-`, consecutive hyphens collapsed, leading/trailing hyphens stripped. Files with already-safe names are unaffected.

---

## Fix 3 — Clean output dir before initial dev build (`dev.ts`)

After any change to auto-router URL structure (e.g. applying this PR), old HTML files built under the previous URL structure remain in `site/`. New nav links point to new URLs but new files may not exist yet — causing 404 on nav click. **Added `fs.remove(rootOutputDir)` before the initial dev build** so every `docmd dev` session starts clean.

---

## Fix 4 — Full rebuild on file watch (`dev.ts`)

The file watcher called `buildSite` with `targetFiles: [filePath]`, regenerating only the modified page. Every other page kept its old nav HTML. Adding a new `.md` file while the dev server was running meant the link never appeared in the sidebar of existing pages. **Removed `targetFiles`** from the watcher rebuild so every change triggers a full rebuild (~200–300 ms for typical doc projects).

---

## Note

With Fix 1, `_sourceFile` is never set on nav items, so the `navDesignatedIndexFiles` logic in `generator.ts` becomes a no-op. Left in place as it may be useful for future features.