### PR TITLE
Fix open API styles in dark mode

### DIFF
--- a/packages/plugins/openapi/src/openapi.css
+++ b/packages/plugins/openapi/src/openapi.css
@@ -345,6 +345,38 @@
 }
 
 /* Dark Mode Overrides */
+
+:root[data-theme=dark] .oa-operation {
+  background: var(--sidebar-bg, #111113);
+}
+
+:root[data-theme=dark] .oa-schema-table th {
+  background: var(--code-bg, #16161a);
+}
+
+:root[data-theme=dark] .oa-schema-table td {
+  background: transparent;
+}
+
+:root[data-theme=dark] .oa-spec-version,
+:root[data-theme=dark] .oa-param-in {
+  background: var(--code-bg, #16161a);
+}
+
+:root[data-theme=dark] .oa-deprecated {
+  background: rgba(153, 27, 27, 0.35);
+  color: #fca5a5;
+}
+
+:root[data-theme=dark] .oa-example-value {
+  background: var(--code-bg, #16161a);
+}
+
+:root[data-theme=dark] .oa-response-detail,
+:root[data-theme=dark] .oa-variant {
+  background: transparent;
+}
+
 :root[data-theme=dark] .oa-type {
   color: #22d3ee;
 }


### PR DESCRIPTION
 Close #207

## Description
Fix dark color scheme when display tables in rendered open api spec, now background is the same as on other pages in dark mode.

<img width="1552" height="1061" alt="image" src="https://github.com/user-attachments/assets/c259f642-df2f-4b8e-9161-57cc3e2abc2a" />


Fixes #207

## Type of change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings