### PR TITLE
fix(api): register auto-installed plugins/templates (regression in 0.9.5)

### DIFF
--- a/packages/api/src/hooks.ts
+++ b/packages/api/src/hooks.ts
@@ -578,6 +578,7 @@ export async function loadPlugins(config: any, opts?: { resolvePaths?: string[];
             );
             continue;
           }
+          rawModule = reloaded;
         } else {
           // Fallback: if auto-install failed (e.g. pre-release version not yet published on npm),
           // check if the package is available in the local monorepo


### PR DESCRIPTION


## Description

Since 0.9.5, plugins and templates that are auto-installed at build time
(e.g. `theme.template: "summer"` without `@docmd/template-summer` in
package.json) are downloaded but never registered. `tryLoadAfterInstall`
returns the module, but `rawModule = reloaded;` was dropped in 0.9.5, so
`rawModule` stays undefined and the loader hits `if (!rawModule) continue;`.
The build silently falls back to the default layout.

Repro: clean project, `@docmd/core@0.9.5`, `theme.template: "summer"`,
`docmd build`. Log shows "Runtime dep done: summer" but the output has no
`assets/template/summer.css`. Works on 0.9.4 and with the package
pre-installed.

Fixes # (issue)

## Type of change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings


disclaimer: fixed by claude